### PR TITLE
Update Mangata Kusama endpoint and its SDK version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@inquirer/confirm": "^0.0.19-alpha.0",
         "@inquirer/select": "^0.0.18-alpha.0",
-        "@mangata-finance/sdk": "^1.19.8",
+        "@mangata-finance/sdk": "^1.20.1",
         "@oak-network/api-augment": "^1.8.1",
         "@oak-network/types": "^1.8.1",
         "@polkadot/api": "^9.3.3",
@@ -2360,18 +2360,524 @@
       }
     },
     "node_modules/@mangata-finance/sdk": {
-      "version": "1.19.8",
-      "resolved": "https://registry.npmmirror.com/@mangata-finance/sdk/-/sdk-1.19.8.tgz",
-      "integrity": "sha512-f6boN/FC0WIcJ5pfBUd8L3oVm9ncdguJIDrz5dxwqfOI24t1V1McjIwG0l5j5xA4XlbrGdBDx/jV9Gb1kV738A==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/@mangata-finance/sdk/-/sdk-1.20.1.tgz",
+      "integrity": "sha512-5dY/fdtVCZJewGoEaW48dREUi279ahq4Xye1uAHGUtpoMJG/8SKxEnmEKFmFadfslTcuUFdyeMYgAQwNbNw5lQ==",
       "dependencies": {
         "@mangata-finance/types": "^0.23.0",
-        "@polkadot/api": "^9.14.2",
+        "@polkadot/api": "^10.7.3",
         "big.js": "^6.2.1",
         "uuid": "^9.0.0"
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@noble/hashes": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/api": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-10.9.1.tgz",
+      "integrity": "sha512-ND/2UqZBWvtt4PfV03OStTKg0mxmPk4UpMAgJKutdgsz/wP9CYJ1KbjwFgPNekL9JnzbKQsWyQNPVrcw7kQk8A==",
+      "dependencies": {
+        "@polkadot/api-augment": "10.9.1",
+        "@polkadot/api-base": "10.9.1",
+        "@polkadot/api-derive": "10.9.1",
+        "@polkadot/keyring": "^12.3.1",
+        "@polkadot/rpc-augment": "10.9.1",
+        "@polkadot/rpc-core": "10.9.1",
+        "@polkadot/rpc-provider": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-augment": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/types-create": "10.9.1",
+        "@polkadot/types-known": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "@polkadot/util-crypto": "^12.3.1",
+        "eventemitter3": "^5.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/api-augment": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-10.9.1.tgz",
+      "integrity": "sha512-kRZZvCFVcN4hAH4dJ+Qzfdy27/4EEq3oLDf3ihj0LTVrAezSWcKPGE3EVFy+Mn6Lo4SUc7RVyoKvIUhSk2l4Dg==",
+      "dependencies": {
+        "@polkadot/api-base": "10.9.1",
+        "@polkadot/rpc-augment": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-augment": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/api-base": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.9.1.tgz",
+      "integrity": "sha512-Q3m2KzlceMK2kX8bhnUZWk3RT6emmijeeFZZQgCePpEcrSeNjnqG4qjuTPgkveaOkUT8MAoDc5Avuzcc2jlW9g==",
+      "dependencies": {
+        "@polkadot/rpc-core": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/api-derive": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-10.9.1.tgz",
+      "integrity": "sha512-mRud1UZCFIc4Z63qAoGSIHh/foyUYADfy1RQYCmPpeFKfIdCIrHpd7xFdJXTOMYOS0BwlM6u4qli/ZT4XigezQ==",
+      "dependencies": {
+        "@polkadot/api": "10.9.1",
+        "@polkadot/api-augment": "10.9.1",
+        "@polkadot/api-base": "10.9.1",
+        "@polkadot/rpc-core": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "@polkadot/util-crypto": "^12.3.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/keyring": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.3.2.tgz",
+      "integrity": "sha512-NTdtDeI0DP9l/45hXynNABeP5VB8piw5YR+CbUxK2e36xpJWVXwbcOepzslg5ghE9rs8UKJb30Z/HqTU4sBY0Q==",
+      "dependencies": {
+        "@polkadot/util": "12.3.2",
+        "@polkadot/util-crypto": "12.3.2",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "12.3.2",
+        "@polkadot/util-crypto": "12.3.2"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/networks": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.3.2.tgz",
+      "integrity": "sha512-uCkyybKoeEm1daKr0uT/9oNDHDDzCy2/ZdVl346hQqfdR1Ct3BaxMjxqvdmb5N8aCw0cBWSfgsxAYtw8ESmllQ==",
+      "dependencies": {
+        "@polkadot/util": "12.3.2",
+        "@substrate/ss58-registry": "^1.40.0",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/rpc-augment": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-10.9.1.tgz",
+      "integrity": "sha512-MaLHkNlyqN20ZRYr6uNd1BZr1OsrnX9qLAmsl0mcrri1vPGRH6VHjfFH1RBLkikpWD82v17g0l2hLwdV1ZHMcw==",
+      "dependencies": {
+        "@polkadot/rpc-core": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/rpc-core": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-10.9.1.tgz",
+      "integrity": "sha512-ZtA8B8SfXSAwVkBlCcKRHw0eSM7ec/sbiNOM5GasXPeRujUgT7lOwSH2GbUZSqe9RfRDMp6DvO9c2JoGc3LLWw==",
+      "dependencies": {
+        "@polkadot/rpc-augment": "10.9.1",
+        "@polkadot/rpc-provider": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/rpc-provider": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.9.1.tgz",
+      "integrity": "sha512-4QzT2QzD+320+eT6b79sGAA85Tt3Bb8fQvse4r5Mom2iiBd2SO81vOhxSAOaIe4GUsw25VzFJmsbe7+OObItdg==",
+      "dependencies": {
+        "@polkadot/keyring": "^12.3.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-support": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "@polkadot/util-crypto": "^12.3.1",
+        "@polkadot/x-fetch": "^12.3.1",
+        "@polkadot/x-global": "^12.3.1",
+        "@polkadot/x-ws": "^12.3.1",
+        "eventemitter3": "^5.0.1",
+        "mock-socket": "^9.2.1",
+        "nock": "^13.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@substrate/connect": "0.7.26"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/types": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+      "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+      "dependencies": {
+        "@polkadot/keyring": "^12.3.1",
+        "@polkadot/types-augment": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/types-create": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "@polkadot/util-crypto": "^12.3.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/types-augment": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+      "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+      "dependencies": {
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/types-codec": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+      "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+      "dependencies": {
+        "@polkadot/util": "^12.3.1",
+        "@polkadot/x-bigint": "^12.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/types-create": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+      "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+      "dependencies": {
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/types-known": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-10.9.1.tgz",
+      "integrity": "sha512-zCMVWc4pJtkbMFPu72bD4IhvV/gkHXPX3C5uu92WdmCfnn0vEIEsMKWlVXVVvQQZKAqvs/awpqIfrUtEViOGEA==",
+      "dependencies": {
+        "@polkadot/networks": "^12.3.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/types-create": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/types-support": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.9.1.tgz",
+      "integrity": "sha512-XsieuLDsszvMZQlleacQBfx07i/JkwQV/UxH9q8Hz7Okmaz9pEVEW1h3ka2/cPuC7a4l32JhaORBUYshBZNdJg==",
+      "dependencies": {
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/util": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.3.2.tgz",
+      "integrity": "sha512-y/JShcGyOamCUiSIg++XZuLHt1ktSKBaSH2K5Nw5NXlgP0+7am+GZzqPB8fQ4qhYLruEOv+YRiz0GC1Zr9S+wg==",
+      "dependencies": {
+        "@polkadot/x-bigint": "12.3.2",
+        "@polkadot/x-global": "12.3.2",
+        "@polkadot/x-textdecoder": "12.3.2",
+        "@polkadot/x-textencoder": "12.3.2",
+        "@types/bn.js": "^5.1.1",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/util-crypto": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.3.2.tgz",
+      "integrity": "sha512-pTpx+YxolY0BDT4RcGmgeKbHHD/dI6Ll9xRsqmVdIjpcVVY20uDNTyXs81ZNtfKgyod1y9JQkfNv2Dz9iEpTkQ==",
+      "dependencies": {
+        "@noble/curves": "1.1.0",
+        "@noble/hashes": "1.3.1",
+        "@polkadot/networks": "12.3.2",
+        "@polkadot/util": "12.3.2",
+        "@polkadot/wasm-crypto": "^7.2.1",
+        "@polkadot/wasm-util": "^7.2.1",
+        "@polkadot/x-bigint": "12.3.2",
+        "@polkadot/x-randomvalues": "12.3.2",
+        "@scure/base": "1.1.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "12.3.2"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/wasm-bridge": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.2.1.tgz",
+      "integrity": "sha512-uV/LHREDBGBbHrrv7HTki+Klw0PYZzFomagFWII4lp6Toj/VCvRh5WMzooVC+g/XsBGosAwrvBhoModabyHx+A==",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.2.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/wasm-crypto": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.2.1.tgz",
+      "integrity": "sha512-SA2+33S9TAwGhniKgztVN6pxUKpGfN4Tre/eUZGUfpgRkT92wIUT2GpGWQE+fCCqGQgADrNiBcwt6XwdPqMQ4Q==",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.2.1",
+        "@polkadot/wasm-crypto-asmjs": "7.2.1",
+        "@polkadot/wasm-crypto-init": "7.2.1",
+        "@polkadot/wasm-crypto-wasm": "7.2.1",
+        "@polkadot/wasm-util": "7.2.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/wasm-crypto-asmjs": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.2.1.tgz",
+      "integrity": "sha512-z/d21bmxyVfkzGsKef/FWswKX02x5lK97f4NPBZ9XBeiFkmzlXhdSnu58/+b1sKsRAGdW/Rn/rTNRDhW0GqCAg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/wasm-crypto-init": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.2.1.tgz",
+      "integrity": "sha512-GcEXtwN9LcSf32V9zSaYjHImFw16hCyo2Xzg4GLLDPPeaAAfbFr2oQMgwyDbvBrBjLKHVHjsPZyGhXae831amw==",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.2.1",
+        "@polkadot/wasm-crypto-asmjs": "7.2.1",
+        "@polkadot/wasm-crypto-wasm": "7.2.1",
+        "@polkadot/wasm-util": "7.2.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/wasm-crypto-wasm": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.2.1.tgz",
+      "integrity": "sha512-DqyXE4rSD0CVlLIw88B58+HHNyrvm+JAnYyuEDYZwCvzUWOCNos/DDg9wi/K39VAIsCCKDmwKqkkfIofuOj/lA==",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.2.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/wasm-util": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.2.1.tgz",
+      "integrity": "sha512-FBSn/3aYJzhN0sYAYhHB8y9JL8mVgxLy4M1kUXYbyo+8GLRQEN5rns8Vcb8TAlIzBWgVTOOptYBvxo0oj0h7Og==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/x-bigint": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+      "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+      "dependencies": {
+        "@polkadot/x-global": "12.3.2",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/x-fetch": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.3.2.tgz",
+      "integrity": "sha512-3IEuZ5S+RI/t33NsdPLIIa5COfDCfpUW2sbaByEczn75aD1jLqJZSEDwiBniJ2osyNd4uUxBf6e5jw7LAZeZJg==",
+      "dependencies": {
+        "@polkadot/x-global": "12.3.2",
+        "node-fetch": "^3.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/x-global": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+      "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+      "dependencies": {
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/x-randomvalues": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.3.2.tgz",
+      "integrity": "sha512-ywjIs8CWpvOGmq+3cGCNPOHxAjPHdBUiXyDccftx5BRVdmtbt36gK/V84bKr6Xs73FGu0jprUAOSRRsLZX/3dg==",
+      "dependencies": {
+        "@polkadot/x-global": "12.3.2",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "12.3.2",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/x-textdecoder": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.3.2.tgz",
+      "integrity": "sha512-lY5bfA5xArJRWEJlYOlQQMJeTjWD8s0yMhchirVgf5xj8Id9vPGeUoneH+VFDEwgXxrqBvDFJ4smN4T/r6a/fg==",
+      "dependencies": {
+        "@polkadot/x-global": "12.3.2",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/x-textencoder": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.3.2.tgz",
+      "integrity": "sha512-iP3qEBiHzBckQ9zeY7ZHRWuu7mCEg5SMpOugs6UODRk8sx6KHzGQYlghBbWLit0uppPDVE0ifEwZ2n73djJHWQ==",
+      "dependencies": {
+        "@polkadot/x-global": "12.3.2",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@polkadot/x-ws": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.3.2.tgz",
+      "integrity": "sha512-yM9Z64pLNlHpJE43+Xtr+iUXmYpFFY5u5hrke2PJt13O48H8f9Vb9cRaIh94appLyICoS0aekGhDkGH+MCspBA==",
+      "dependencies": {
+        "@polkadot/x-global": "12.3.2",
+        "tslib": "^2.5.3",
+        "ws": "^8.13.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@substrate/connect": {
+      "version": "0.7.26",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.26.tgz",
+      "integrity": "sha512-uuGSiroGuKWj1+38n1kY5HReer5iL9bRwPCzuoLtqAOmI1fGI0hsSI2LlNQMAbfRgr7VRHXOk5MTuQf5ulsFRw==",
+      "optional": true,
+      "dependencies": {
+        "@substrate/connect-extension-protocol": "^1.0.1",
+        "eventemitter3": "^4.0.7",
+        "smoldot": "1.0.4"
+      }
+    },
+    "node_modules/@mangata-finance/sdk/node_modules/@substrate/connect/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "optional": true
     },
     "node_modules/@mangata-finance/types": {
       "version": "0.23.0",
@@ -2410,6 +2916,28 @@
       "dev": true,
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
+      "integrity": "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==",
+      "dependencies": {
+        "@noble/hashes": "1.3.1"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
@@ -7403,9 +7931,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmmirror.com/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -7618,6 +8146,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/smoldot": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-1.0.4.tgz",
+      "integrity": "sha512-N3TazI1C4GGrseFH/piWyZCCCRJTRx2QhDfrUKRT4SzILlW5m8ayZ3QTKICcz1C/536T9cbHHJyP7afxI6Mi1A==",
+      "optional": true,
+      "dependencies": {
+        "pako": "^2.0.4",
+        "ws": "^8.8.1"
       }
     },
     "node_modules/source-map": {
@@ -8022,9 +8560,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -8821,7 +9359,6 @@
       "version": "8.13.0",
       "resolved": "https://registry.npmmirror.com/ws/-/ws-8.13.0.tgz",
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "optional": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10622,14 +11159,394 @@
       }
     },
     "@mangata-finance/sdk": {
-      "version": "1.19.8",
-      "resolved": "https://registry.npmmirror.com/@mangata-finance/sdk/-/sdk-1.19.8.tgz",
-      "integrity": "sha512-f6boN/FC0WIcJ5pfBUd8L3oVm9ncdguJIDrz5dxwqfOI24t1V1McjIwG0l5j5xA4XlbrGdBDx/jV9Gb1kV738A==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/@mangata-finance/sdk/-/sdk-1.20.1.tgz",
+      "integrity": "sha512-5dY/fdtVCZJewGoEaW48dREUi279ahq4Xye1uAHGUtpoMJG/8SKxEnmEKFmFadfslTcuUFdyeMYgAQwNbNw5lQ==",
       "requires": {
         "@mangata-finance/types": "^0.23.0",
-        "@polkadot/api": "^9.14.2",
+        "@polkadot/api": "^10.7.3",
         "big.js": "^6.2.1",
         "uuid": "^9.0.0"
+      },
+      "dependencies": {
+        "@noble/hashes": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+          "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA=="
+        },
+        "@polkadot/api": {
+          "version": "10.9.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-10.9.1.tgz",
+          "integrity": "sha512-ND/2UqZBWvtt4PfV03OStTKg0mxmPk4UpMAgJKutdgsz/wP9CYJ1KbjwFgPNekL9JnzbKQsWyQNPVrcw7kQk8A==",
+          "requires": {
+            "@polkadot/api-augment": "10.9.1",
+            "@polkadot/api-base": "10.9.1",
+            "@polkadot/api-derive": "10.9.1",
+            "@polkadot/keyring": "^12.3.1",
+            "@polkadot/rpc-augment": "10.9.1",
+            "@polkadot/rpc-core": "10.9.1",
+            "@polkadot/rpc-provider": "10.9.1",
+            "@polkadot/types": "10.9.1",
+            "@polkadot/types-augment": "10.9.1",
+            "@polkadot/types-codec": "10.9.1",
+            "@polkadot/types-create": "10.9.1",
+            "@polkadot/types-known": "10.9.1",
+            "@polkadot/util": "^12.3.1",
+            "@polkadot/util-crypto": "^12.3.1",
+            "eventemitter3": "^5.0.1",
+            "rxjs": "^7.8.1",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/api-augment": {
+          "version": "10.9.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-10.9.1.tgz",
+          "integrity": "sha512-kRZZvCFVcN4hAH4dJ+Qzfdy27/4EEq3oLDf3ihj0LTVrAezSWcKPGE3EVFy+Mn6Lo4SUc7RVyoKvIUhSk2l4Dg==",
+          "requires": {
+            "@polkadot/api-base": "10.9.1",
+            "@polkadot/rpc-augment": "10.9.1",
+            "@polkadot/types": "10.9.1",
+            "@polkadot/types-augment": "10.9.1",
+            "@polkadot/types-codec": "10.9.1",
+            "@polkadot/util": "^12.3.1",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/api-base": {
+          "version": "10.9.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.9.1.tgz",
+          "integrity": "sha512-Q3m2KzlceMK2kX8bhnUZWk3RT6emmijeeFZZQgCePpEcrSeNjnqG4qjuTPgkveaOkUT8MAoDc5Avuzcc2jlW9g==",
+          "requires": {
+            "@polkadot/rpc-core": "10.9.1",
+            "@polkadot/types": "10.9.1",
+            "@polkadot/util": "^12.3.1",
+            "rxjs": "^7.8.1",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/api-derive": {
+          "version": "10.9.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-10.9.1.tgz",
+          "integrity": "sha512-mRud1UZCFIc4Z63qAoGSIHh/foyUYADfy1RQYCmPpeFKfIdCIrHpd7xFdJXTOMYOS0BwlM6u4qli/ZT4XigezQ==",
+          "requires": {
+            "@polkadot/api": "10.9.1",
+            "@polkadot/api-augment": "10.9.1",
+            "@polkadot/api-base": "10.9.1",
+            "@polkadot/rpc-core": "10.9.1",
+            "@polkadot/types": "10.9.1",
+            "@polkadot/types-codec": "10.9.1",
+            "@polkadot/util": "^12.3.1",
+            "@polkadot/util-crypto": "^12.3.1",
+            "rxjs": "^7.8.1",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/keyring": {
+          "version": "12.3.2",
+          "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.3.2.tgz",
+          "integrity": "sha512-NTdtDeI0DP9l/45hXynNABeP5VB8piw5YR+CbUxK2e36xpJWVXwbcOepzslg5ghE9rs8UKJb30Z/HqTU4sBY0Q==",
+          "requires": {
+            "@polkadot/util": "12.3.2",
+            "@polkadot/util-crypto": "12.3.2",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/networks": {
+          "version": "12.3.2",
+          "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.3.2.tgz",
+          "integrity": "sha512-uCkyybKoeEm1daKr0uT/9oNDHDDzCy2/ZdVl346hQqfdR1Ct3BaxMjxqvdmb5N8aCw0cBWSfgsxAYtw8ESmllQ==",
+          "requires": {
+            "@polkadot/util": "12.3.2",
+            "@substrate/ss58-registry": "^1.40.0",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/rpc-augment": {
+          "version": "10.9.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-10.9.1.tgz",
+          "integrity": "sha512-MaLHkNlyqN20ZRYr6uNd1BZr1OsrnX9qLAmsl0mcrri1vPGRH6VHjfFH1RBLkikpWD82v17g0l2hLwdV1ZHMcw==",
+          "requires": {
+            "@polkadot/rpc-core": "10.9.1",
+            "@polkadot/types": "10.9.1",
+            "@polkadot/types-codec": "10.9.1",
+            "@polkadot/util": "^12.3.1",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/rpc-core": {
+          "version": "10.9.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-10.9.1.tgz",
+          "integrity": "sha512-ZtA8B8SfXSAwVkBlCcKRHw0eSM7ec/sbiNOM5GasXPeRujUgT7lOwSH2GbUZSqe9RfRDMp6DvO9c2JoGc3LLWw==",
+          "requires": {
+            "@polkadot/rpc-augment": "10.9.1",
+            "@polkadot/rpc-provider": "10.9.1",
+            "@polkadot/types": "10.9.1",
+            "@polkadot/util": "^12.3.1",
+            "rxjs": "^7.8.1",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/rpc-provider": {
+          "version": "10.9.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.9.1.tgz",
+          "integrity": "sha512-4QzT2QzD+320+eT6b79sGAA85Tt3Bb8fQvse4r5Mom2iiBd2SO81vOhxSAOaIe4GUsw25VzFJmsbe7+OObItdg==",
+          "requires": {
+            "@polkadot/keyring": "^12.3.1",
+            "@polkadot/types": "10.9.1",
+            "@polkadot/types-support": "10.9.1",
+            "@polkadot/util": "^12.3.1",
+            "@polkadot/util-crypto": "^12.3.1",
+            "@polkadot/x-fetch": "^12.3.1",
+            "@polkadot/x-global": "^12.3.1",
+            "@polkadot/x-ws": "^12.3.1",
+            "@substrate/connect": "0.7.26",
+            "eventemitter3": "^5.0.1",
+            "mock-socket": "^9.2.1",
+            "nock": "^13.3.1",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/types": {
+          "version": "10.9.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+          "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+          "requires": {
+            "@polkadot/keyring": "^12.3.1",
+            "@polkadot/types-augment": "10.9.1",
+            "@polkadot/types-codec": "10.9.1",
+            "@polkadot/types-create": "10.9.1",
+            "@polkadot/util": "^12.3.1",
+            "@polkadot/util-crypto": "^12.3.1",
+            "rxjs": "^7.8.1",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/types-augment": {
+          "version": "10.9.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+          "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+          "requires": {
+            "@polkadot/types": "10.9.1",
+            "@polkadot/types-codec": "10.9.1",
+            "@polkadot/util": "^12.3.1",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/types-codec": {
+          "version": "10.9.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+          "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+          "requires": {
+            "@polkadot/util": "^12.3.1",
+            "@polkadot/x-bigint": "^12.3.1",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/types-create": {
+          "version": "10.9.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+          "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+          "requires": {
+            "@polkadot/types-codec": "10.9.1",
+            "@polkadot/util": "^12.3.1",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/types-known": {
+          "version": "10.9.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-10.9.1.tgz",
+          "integrity": "sha512-zCMVWc4pJtkbMFPu72bD4IhvV/gkHXPX3C5uu92WdmCfnn0vEIEsMKWlVXVVvQQZKAqvs/awpqIfrUtEViOGEA==",
+          "requires": {
+            "@polkadot/networks": "^12.3.1",
+            "@polkadot/types": "10.9.1",
+            "@polkadot/types-codec": "10.9.1",
+            "@polkadot/types-create": "10.9.1",
+            "@polkadot/util": "^12.3.1",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/types-support": {
+          "version": "10.9.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.9.1.tgz",
+          "integrity": "sha512-XsieuLDsszvMZQlleacQBfx07i/JkwQV/UxH9q8Hz7Okmaz9pEVEW1h3ka2/cPuC7a4l32JhaORBUYshBZNdJg==",
+          "requires": {
+            "@polkadot/util": "^12.3.1",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/util": {
+          "version": "12.3.2",
+          "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.3.2.tgz",
+          "integrity": "sha512-y/JShcGyOamCUiSIg++XZuLHt1ktSKBaSH2K5Nw5NXlgP0+7am+GZzqPB8fQ4qhYLruEOv+YRiz0GC1Zr9S+wg==",
+          "requires": {
+            "@polkadot/x-bigint": "12.3.2",
+            "@polkadot/x-global": "12.3.2",
+            "@polkadot/x-textdecoder": "12.3.2",
+            "@polkadot/x-textencoder": "12.3.2",
+            "@types/bn.js": "^5.1.1",
+            "bn.js": "^5.2.1",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/util-crypto": {
+          "version": "12.3.2",
+          "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.3.2.tgz",
+          "integrity": "sha512-pTpx+YxolY0BDT4RcGmgeKbHHD/dI6Ll9xRsqmVdIjpcVVY20uDNTyXs81ZNtfKgyod1y9JQkfNv2Dz9iEpTkQ==",
+          "requires": {
+            "@noble/curves": "1.1.0",
+            "@noble/hashes": "1.3.1",
+            "@polkadot/networks": "12.3.2",
+            "@polkadot/util": "12.3.2",
+            "@polkadot/wasm-crypto": "^7.2.1",
+            "@polkadot/wasm-util": "^7.2.1",
+            "@polkadot/x-bigint": "12.3.2",
+            "@polkadot/x-randomvalues": "12.3.2",
+            "@scure/base": "1.1.1",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/wasm-bridge": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.2.1.tgz",
+          "integrity": "sha512-uV/LHREDBGBbHrrv7HTki+Klw0PYZzFomagFWII4lp6Toj/VCvRh5WMzooVC+g/XsBGosAwrvBhoModabyHx+A==",
+          "requires": {
+            "@polkadot/wasm-util": "7.2.1",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@polkadot/wasm-crypto": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.2.1.tgz",
+          "integrity": "sha512-SA2+33S9TAwGhniKgztVN6pxUKpGfN4Tre/eUZGUfpgRkT92wIUT2GpGWQE+fCCqGQgADrNiBcwt6XwdPqMQ4Q==",
+          "requires": {
+            "@polkadot/wasm-bridge": "7.2.1",
+            "@polkadot/wasm-crypto-asmjs": "7.2.1",
+            "@polkadot/wasm-crypto-init": "7.2.1",
+            "@polkadot/wasm-crypto-wasm": "7.2.1",
+            "@polkadot/wasm-util": "7.2.1",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@polkadot/wasm-crypto-asmjs": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.2.1.tgz",
+          "integrity": "sha512-z/d21bmxyVfkzGsKef/FWswKX02x5lK97f4NPBZ9XBeiFkmzlXhdSnu58/+b1sKsRAGdW/Rn/rTNRDhW0GqCAg==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@polkadot/wasm-crypto-init": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.2.1.tgz",
+          "integrity": "sha512-GcEXtwN9LcSf32V9zSaYjHImFw16hCyo2Xzg4GLLDPPeaAAfbFr2oQMgwyDbvBrBjLKHVHjsPZyGhXae831amw==",
+          "requires": {
+            "@polkadot/wasm-bridge": "7.2.1",
+            "@polkadot/wasm-crypto-asmjs": "7.2.1",
+            "@polkadot/wasm-crypto-wasm": "7.2.1",
+            "@polkadot/wasm-util": "7.2.1",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@polkadot/wasm-crypto-wasm": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.2.1.tgz",
+          "integrity": "sha512-DqyXE4rSD0CVlLIw88B58+HHNyrvm+JAnYyuEDYZwCvzUWOCNos/DDg9wi/K39VAIsCCKDmwKqkkfIofuOj/lA==",
+          "requires": {
+            "@polkadot/wasm-util": "7.2.1",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@polkadot/wasm-util": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.2.1.tgz",
+          "integrity": "sha512-FBSn/3aYJzhN0sYAYhHB8y9JL8mVgxLy4M1kUXYbyo+8GLRQEN5rns8Vcb8TAlIzBWgVTOOptYBvxo0oj0h7Og==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@polkadot/x-bigint": {
+          "version": "12.3.2",
+          "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+          "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+          "requires": {
+            "@polkadot/x-global": "12.3.2",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/x-fetch": {
+          "version": "12.3.2",
+          "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.3.2.tgz",
+          "integrity": "sha512-3IEuZ5S+RI/t33NsdPLIIa5COfDCfpUW2sbaByEczn75aD1jLqJZSEDwiBniJ2osyNd4uUxBf6e5jw7LAZeZJg==",
+          "requires": {
+            "@polkadot/x-global": "12.3.2",
+            "node-fetch": "^3.3.1",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/x-global": {
+          "version": "12.3.2",
+          "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+          "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+          "requires": {
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/x-randomvalues": {
+          "version": "12.3.2",
+          "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.3.2.tgz",
+          "integrity": "sha512-ywjIs8CWpvOGmq+3cGCNPOHxAjPHdBUiXyDccftx5BRVdmtbt36gK/V84bKr6Xs73FGu0jprUAOSRRsLZX/3dg==",
+          "requires": {
+            "@polkadot/x-global": "12.3.2",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/x-textdecoder": {
+          "version": "12.3.2",
+          "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.3.2.tgz",
+          "integrity": "sha512-lY5bfA5xArJRWEJlYOlQQMJeTjWD8s0yMhchirVgf5xj8Id9vPGeUoneH+VFDEwgXxrqBvDFJ4smN4T/r6a/fg==",
+          "requires": {
+            "@polkadot/x-global": "12.3.2",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/x-textencoder": {
+          "version": "12.3.2",
+          "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.3.2.tgz",
+          "integrity": "sha512-iP3qEBiHzBckQ9zeY7ZHRWuu7mCEg5SMpOugs6UODRk8sx6KHzGQYlghBbWLit0uppPDVE0ifEwZ2n73djJHWQ==",
+          "requires": {
+            "@polkadot/x-global": "12.3.2",
+            "tslib": "^2.5.3"
+          }
+        },
+        "@polkadot/x-ws": {
+          "version": "12.3.2",
+          "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.3.2.tgz",
+          "integrity": "sha512-yM9Z64pLNlHpJE43+Xtr+iUXmYpFFY5u5hrke2PJt13O48H8f9Vb9cRaIh94appLyICoS0aekGhDkGH+MCspBA==",
+          "requires": {
+            "@polkadot/x-global": "12.3.2",
+            "tslib": "^2.5.3",
+            "ws": "^8.13.0"
+          }
+        },
+        "@substrate/connect": {
+          "version": "0.7.26",
+          "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.26.tgz",
+          "integrity": "sha512-uuGSiroGuKWj1+38n1kY5HReer5iL9bRwPCzuoLtqAOmI1fGI0hsSI2LlNQMAbfRgr7VRHXOk5MTuQf5ulsFRw==",
+          "optional": true,
+          "requires": {
+            "@substrate/connect-extension-protocol": "^1.0.1",
+            "eventemitter3": "^4.0.7",
+            "smoldot": "1.0.4"
+          },
+          "dependencies": {
+            "eventemitter3": {
+              "version": "4.0.7",
+              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+              "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+              "optional": true
+            }
+          }
+        }
       }
     },
     "@mangata-finance/types": {
@@ -10664,6 +11581,21 @@
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
           "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
           "dev": true
+        }
+      }
+    },
+    "@noble/curves": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
+      "integrity": "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==",
+      "requires": {
+        "@noble/hashes": "1.3.1"
+      },
+      "dependencies": {
+        "@noble/hashes": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+          "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA=="
         }
       }
     },
@@ -14664,9 +15596,9 @@
       }
     },
     "rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmmirror.com/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -14854,6 +15786,16 @@
             "mimic-response": "^1.0.0"
           }
         }
+      }
+    },
+    "smoldot": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-1.0.4.tgz",
+      "integrity": "sha512-N3TazI1C4GGrseFH/piWyZCCCRJTRx2QhDfrUKRT4SzILlW5m8ayZ3QTKICcz1C/536T9cbHHJyP7afxI6Mi1A==",
+      "optional": true,
+      "requires": {
+        "pako": "^2.0.4",
+        "ws": "^8.8.1"
       }
     },
     "source-map": {
@@ -15163,9 +16105,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -15816,7 +16758,6 @@
       "version": "8.13.0",
       "resolved": "https://registry.npmmirror.com/ws/-/ws-8.13.0.tgz",
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "optional": true,
       "requires": {}
     },
     "xhr": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@inquirer/confirm": "^0.0.19-alpha.0",
     "@inquirer/select": "^0.0.18-alpha.0",
-    "@mangata-finance/sdk": "^1.19.8",
+    "@mangata-finance/sdk": "^1.20.1",
     "@oak-network/api-augment": "^1.8.1",
     "@oak-network/types": "^1.8.1",
     "@polkadot/api": "^9.3.3",

--- a/src/config/mangata.js
+++ b/src/config/mangata.js
@@ -189,7 +189,7 @@ const pools = [
 const Config = {
     name: 'Mangata',
     key: 'mangata',
-    endpoint: 'wss://prod-kusama-collator-01.mangatafinance.cloud',
+    endpoint: 'wss://kusama-rpc.mangata.online',
     relayChain: 'Kusama',
     paraId: 2110,
     ss58: 42,


### PR DESCRIPTION
The previous version of @mangata-finance/sdk is not able to get pools on Mangata after runtime 3000, so we need to upgrade it.