### PR TITLE
Update Mangata runtime 3001

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ MessageHash: 0xff304ed6aeab3e174ec667e9f69a18ebe23506836c4f53bd35aeb78503193453
 | Chain      | Version | 
 | :---        |    :----:   | 
 | Polkadot      | [v0.9.38](https://github.com/paritytech/polkadot/releases/tag/v0.9.38)       |
-| OAK-blockchain   | [v1.9.0](https://github.com/OAK-Foundation/OAK-blockchain/releases/tag/v1.9.0)     |
+| OAK-blockchain   | [v2.0.0](https://github.com/OAK-Foundation/OAK-blockchain/releases/tag/v2.0.0)     |
 | Moonbeam | [runtime-2302](https://github.com/PureStake/moonbeam/releases/tag/runtime-2302)   |
 
 ### Steps & Logs

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 | :---        |    :----:   | 
 | Polkadot      | [v0.9.38](https://github.com/paritytech/polkadot/releases/tag/v0.9.38)       |
 | OAK-blockchain   | [v1.9.0](https://github.com/OAK-Foundation/OAK-blockchain/releases/tag/v1.9.0)     |
-| Mangata-node | [v0.30.0](https://github.com/mangata-finance/mangata-node/pull/501)   |
+| Mangata-node | [v0.30.1](https://github.com/mangata-finance/mangata-node/releases/tag/v0.30.1)   |
 ### Steps & Logs
 <details>
 <summary>Dev environment</summary>
@@ -33,7 +33,7 @@
 
 	- Compile modified Mangata
 
-		https://github.com/mangata-finance/mangata-node/tree/release/v0.30.0
+		https://github.com/mangata-finance/mangata-node/releases/tag/v0.30.1
 
 		```
 		cargo build --release --features mangata-rococo,fast-runtime

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -41,7 +41,7 @@ export const sendExtrinsic = async (api, extrinsic, keyPair, { isSudo = false } 
                 });
 
             if (status.isFinalized) {
-                resolve(status.asFinalized.toString());
+                resolve({ events, blockHash: status.asFinalized.toString() });
             }
         }
     });
@@ -273,3 +273,6 @@ export const calculateXcmOverallWeight = (transactCallWeight, instructionWeight,
     const totalWeight = { refTime: transactCallWeight.refTime.unwrap().add(totalInstructionWeight.refTime), proofSize: transactCallWeight.proofSize.unwrap().add(totalInstructionWeight.proofSize) };
     return totalWeight;
 };
+
+export const findEvent = (events, section, method) => events.find((e) => e.event.section === section && e.event.method === method);
+export const getTaskIdInTaskScheduledEvent = (event) => Buffer.from(event.event.data.taskId).toString();

--- a/src/config/mangata-dev.js
+++ b/src/config/mangata-dev.js
@@ -27,7 +27,7 @@ const assets = [
         name: 'Turing native token',
         symbol: 'TUR',
         address: '',
-        feePerSecond: new BN('537600000000'),
+        feePerSecond: new BN('871400000000'),
     },
 ];
 


### PR DESCRIPTION
1. Modify feePerSecond in config/mangata-dev.js
2. Remove `providedId` in scheduleXcmpTask interface in src/mangata/mangata.js
3. Update the version of Mangata-node to v0.30.1. The updated code for OAK-blockchain hasn't generated a release yet. I will update it later.

Log:
```
Start to schedule an auto-compound call via XCM ...
encodedMangataProxyCall:  0x050000d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d01000d080800000064000000
mangataProxyCallFees:  {
  weight: { refTime: '2,905,398,711', proofSize: '3,716' },
  class: 'Normal',
  partialFee: '27.0780 MGRL'
}

1. Create the call for scheduleXcmpTask 
? Select an action to perform Execute immediately
xcmpCall:  0x3c020004000000000000000003010100f9200300000300007484a6c5000000000000000000000000bc050000d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d01000d08080000006400000003b7dd2cad113a03b7c6d1e2113a

2. Query automationTime fee details 
automationFeeDetails:  { executionFee: '9335556000', xcmpFee: '3316024436' }

3. Sign and send scheduleXcmpTask call ...
status.type Ready
status.type InBlock
status.type Finalized
TaskId: 177-2-3

4. Keep Listening XCM events on mangata-dev until 2023-08-05 12:00:00(1691208000) to verify that the task(taskId: 177-2-3) will be successfully executed ...
        proxy:ProxyExecuted:: (phase={"applyExtrinsic":0})
                        Result<Null, SpRuntimeDispatchError>: {"err":{"module":{"index":14,"error":"0x09000000"}}}
        proxy:ProxyExecuted:: (phase={"applyExtrinsic":0})
                        Result<Null, SpRuntimeDispatchError>: {"err":{"module":{"index":14,"error":"0x09000000"}}}
Task has been executed!
```