### PR TITLE
Update Moonbase-alpha tests with oak-blockchain v2.0.0 

### DIFF
--- a/src/common/moonbaseHelper.js
+++ b/src/common/moonbaseHelper.js
@@ -37,7 +37,9 @@ class MoonbaseHelper {
             ...new TextEncoder().encode(accountType),
             ...decodedAddress,
         ]);
-        return u8aToHex(blake2AsU8a(toHash).slice(0, 32));
+
+        const deriveAccountId = u8aToHex(blake2AsU8a(toHash).slice(0, 32));
+        return this.keyring.encodeAddress(deriveAccountId);
     };
 
     getProxies = async (address) => getProxies(this.api, address);

--- a/src/common/moonbaseHelper.js
+++ b/src/common/moonbaseHelper.js
@@ -38,8 +38,7 @@ class MoonbaseHelper {
             ...decodedAddress,
         ]);
 
-        const deriveAccountId = u8aToHex(blake2AsU8a(toHash).slice(0, 32));
-        return this.keyring.encodeAddress(deriveAccountId);
+        return u8aToHex(blake2AsU8a(toHash).slice(0, 20));
     };
 
     getProxies = async (address) => getProxies(this.api, address);

--- a/src/config/moonbase-alpha.js
+++ b/src/config/moonbase-alpha.js
@@ -11,7 +11,6 @@ const assets = [
         name: 'Moonbase Alpha DEV',
         symbol: 'DEV',
         address: '',
-        feePerSecond: new BN('10000000000000000000'),
     },
 ];
 

--- a/src/config/moonbase-alpha.js
+++ b/src/config/moonbase-alpha.js
@@ -1,3 +1,8 @@
+import BN from 'bn.js';
+
+const WEIGHT_REF_TIME = new BN('250000000');
+const WEIGHT_PROOF_SIZE = new BN('10000');
+
 const assets = [
     {
         id: '0',
@@ -6,6 +11,7 @@ const assets = [
         name: 'Moonbase Alpha DEV',
         symbol: 'DEV',
         address: '',
+        feePerSecond: new BN('10000000000000000000'),
     },
 ];
 
@@ -17,6 +23,7 @@ const Config = {
     paraId: 1000,
     ss58: 1287,
     assets,
+    instructionWeight: { refTime: WEIGHT_REF_TIME, proofSize: WEIGHT_PROOF_SIZE },
 };
 
 export default Config;

--- a/src/config/moonbase-local.js
+++ b/src/config/moonbase-local.js
@@ -11,7 +11,6 @@ const assets = [
         name: 'Moonbase Local Token',
         symbol: 'UNIT',
         address: '',
-        feePerSecond: new BN('10000000000000000000'),
     },
 ];
 

--- a/src/config/turing-moonbase.js
+++ b/src/config/turing-moonbase.js
@@ -1,7 +1,17 @@
+import BN from 'bn.js';
+
+const WEIGHT_REF_TIME = new BN(1_000_000_000);
+const WEIGHT_PROOF_SIZE = new BN(0);
+
 const assets = [
     {
         symbol: 'TUR',
         decimals: 10,
+    },
+    {
+        symbol: 'DEV',
+        decimals: 18,
+        feePerSecond: new BN('10000000000000000000'),
     },
 ];
 
@@ -13,6 +23,7 @@ const Config = {
     paraId: 2114,
     ss58: 51,
     assets,
+    instructionWeight: { refTime: WEIGHT_REF_TIME, proofSize: WEIGHT_PROOF_SIZE },
 };
 
 export default Config;

--- a/src/moonbeam/moonbase-alpha.js
+++ b/src/moonbeam/moonbase-alpha.js
@@ -13,27 +13,17 @@ import {
     // listenEvents, calculateTimeout,
 } from '../common/utils';
 
-// TODO: read this instruction value from Turing Staging
-// One XCM operation is 1_000_000_000 weight - almost certainly a conservative estimate.
-// It is defined as a UnitWeightCost variable in runtime.
-const TURING_INSTRUCTION_WEIGHT = 1000000000;
-// const MIN_BALANCE_IN_PROXY = 0.1 * 1e18; // The proxy accounts are to be topped up if its balance fails below this number
-// const TASK_FREQUENCY = 3600;
-
-const WEIGHT_PER_SECOND = 1000000000000;
-
 const CONTRACT_ADDRESS = '0xa72f549a1a12b9b49f30a7f3aeb1f4e96389c5d8';
 const CONTRACT_INPUT = '0xd09de08a';
 
 const sendXcmFromMoonbase = async ({
-    turingHelper, parachainHelper, turingAddress,
-    paraTokenIdOnTuring, keyPair,
+    turingHelper, parachainHelper, turingAddress, keyPair,
 }) => {
     console.log('\na). Create a payload to store in Turing’s task ...');
     const parachainProxyCall = parachainHelper.api.tx.ethereumXcm.transactThroughProxy(
         keyPair.address,
         {
-            V3: {
+            V2: {
                 gasLimit: 71000,
                 action: { Call: CONTRACT_ADDRESS },
                 value: 0,
@@ -47,44 +37,33 @@ const sendXcmFromMoonbase = async ({
     const currentTimestamp = moment().valueOf();
     const timestampNextHour = (currentTimestamp - (currentTimestamp % millisecondsInHour)) / 1000 + secondsInHour;
     const timestampTwoHoursLater = (currentTimestamp - (currentTimestamp % millisecondsInHour)) / 1000 + (secondsInHour * 2);
-    const payloadExtrinsicWeight = { refTime: '4000000000', proofSize: 0 };
+
+    const payloadExtrinsicWeight = (await parachainProxyCall.paymentInfo(keyPair.address)).weight;
+    const payloadOverallWeight = parachainHelper.calculateXcmTransactOverallWeight(payloadExtrinsicWeight);
+    const payloadXcmpFee = parachainHelper.weightToFee(payloadOverallWeight, 'DEV');
+
     const taskViaProxy = turingHelper.api.tx.automationTime.scheduleXcmpTaskThroughProxy(
         { Fixed: { executionTimes: [timestampNextHour, timestampTwoHoursLater] } },
-        // { Fixed: { executionTimes: [0] } },
-        // { Recurring: { frequency: TASK_FREQUENCY, nextExecutionTime: timestampNextHour } },
-        parachainHelper.config.paraId,
-        paraTokenIdOnTuring,
-        {
-            V3: {
-                parents: 1,
-                interior: { X2: [{ Parachain: parachainHelper.config.paraId }, { PalletInstance: 3 }] },
-            },
-        },
+        { V3: { parents: 1, interior: { X1: { Parachain: parachainHelper.config.paraId } } } },
+        { V3: { parents: 1, interior: { X2: [{ Parachain: parachainHelper.config.paraId }, { PalletInstance: 3 }] } } },
+        { asset_location: { V3: { parents: 1, interior: { X2: [{ Parachain: parachainHelper.config.paraId }, { PalletInstance: 3 }] } } }, amount: payloadXcmpFee },
         parachainProxyCall.method.toHex(),
         payloadExtrinsicWeight,
+        payloadOverallWeight,
         turingAddress,
     );
     console.log(`Task extrinsic encoded call data: ${taskViaProxy.method.toHex()}`);
 
     // const taskExtrinsic = turingHelper.api.tx.system.remarkWithEvent('Hello!!!');
     const encodedTaskViaProxy = taskViaProxy.method.toHex();
-    const taskViaProxyFees = await taskViaProxy.paymentInfo(turingAddress);
-    const requireWeightAtMost = parseInt(taskViaProxyFees.weight.refTime, 10);
+    const { weight: taskViaProxyCallWeight } = await taskViaProxy.paymentInfo(turingAddress);
 
     console.log(`Encoded call data: ${encodedTaskViaProxy}`);
-    console.log(`requireWeightAtMost: ${requireWeightAtMost}`);
+    console.log(`taskViaProxyCallWeight.weight: { refTime: ${taskViaProxyCallWeight.refTime.toString()}, proofSize: ${taskViaProxyCallWeight.proofSize.toString()} }`);
 
     console.log(`\nb) Execute the above an XCM from ${parachainHelper.config.name} to schedule a task on ${turingHelper.config.name} ...`);
-    const feePerSecond = await turingHelper.getFeePerSecond(paraTokenIdOnTuring);
-
-    const instructionCount = 4;
-    const totalInstructionWeight = instructionCount * TURING_INSTRUCTION_WEIGHT;
-    const weightLimit = requireWeightAtMost + totalInstructionWeight;
-    const fungible = new BN(weightLimit).mul(feePerSecond).div(new BN(WEIGHT_PER_SECOND)).mul(new BN(10));
-    const transactRequiredWeightAtMost = requireWeightAtMost + TURING_INSTRUCTION_WEIGHT;
-    // const overallWeight = (instructionCount - 1) * TURING_INSTRUCTION_WEIGHT;
-    const overallWeight = 8170208000;
-    console.log('transactRequiredWeightAtMost: ', transactRequiredWeightAtMost);
+    const overallWeight = turingHelper.calculateXcmTransactOverallWeight(taskViaProxyCallWeight);
+    const fungible = turingHelper.weightToFee(overallWeight, 'DEV');
     console.log('overallWeight: ', overallWeight);
     console.log('fungible: ', fungible.toString());
 
@@ -105,14 +84,8 @@ const sendXcmFromMoonbase = async ({
         },
         encodedTaskViaProxy,
         {
-            transactRequiredWeightAtMost: {
-                refTime: transactRequiredWeightAtMost,
-                proofSize: 0,
-            },
-            overallWeight: {
-                refTime: overallWeight,
-                proofSize: 0,
-            },
+            transactRequiredWeightAtMost: taskViaProxyCallWeight,
+            overallWeight,
         },
     );
 
@@ -257,7 +230,7 @@ const main = async () => {
     console.log(`\n4. Execute an XCM from ${parachainName} to ${turingChainName} ...`);
 
     await sendXcmFromMoonbase({
-        turingHelper, parachainHelper: moonbaseHelper, turingAddress, parachainAddress, paraTokenIdOnTuring, keyPair: parachainKeyPair, proxyAccountId,
+        turingHelper, parachainHelper: moonbaseHelper, turingAddress, parachainAddress, keyPair: parachainKeyPair, proxyAccountId,
     });
 
     // Listen TaskScheduled event on Turing chain

--- a/src/moonbeam/moonbase-alpha.js
+++ b/src/moonbeam/moonbase-alpha.js
@@ -40,7 +40,7 @@ const sendXcmFromMoonbase = async ({
 
     const payloadExtrinsicWeight = (await parachainProxyCall.paymentInfo(keyPair.address)).weight;
     const payloadOverallWeight = parachainHelper.calculateXcmTransactOverallWeight(payloadExtrinsicWeight);
-    const payloadXcmpFee = parachainHelper.api.call.transactionPaymentApi.queryWeightToFee(payloadOverallWeight);
+    const payloadXcmpFee = await parachainHelper.api.call.transactionPaymentApi.queryWeightToFee(payloadOverallWeight);
 
     const taskViaProxy = turingHelper.api.tx.automationTime.scheduleXcmpTaskThroughProxy(
         { Fixed: { executionTimes: [timestampNextHour, timestampTwoHoursLater] } },

--- a/src/moonbeam/moonbase-alpha.js
+++ b/src/moonbeam/moonbase-alpha.js
@@ -40,7 +40,7 @@ const sendXcmFromMoonbase = async ({
 
     const payloadExtrinsicWeight = (await parachainProxyCall.paymentInfo(keyPair.address)).weight;
     const payloadOverallWeight = parachainHelper.calculateXcmTransactOverallWeight(payloadExtrinsicWeight);
-    const payloadXcmpFee = parachainHelper.weightToFee(payloadOverallWeight, 'DEV');
+    const payloadXcmpFee = parachainHelper.api.call.transactionPaymentApi.queryWeightToFee(payloadOverallWeight);
 
     const taskViaProxy = turingHelper.api.tx.automationTime.scheduleXcmpTaskThroughProxy(
         { Fixed: { executionTimes: [timestampNextHour, timestampTwoHoursLater] } },

--- a/src/moonbeam/moonbase-local.js
+++ b/src/moonbeam/moonbase-local.js
@@ -240,7 +240,7 @@ const main = async () => {
 
     const payloadExtrinsicWeight = (await payloadExtrinsic.paymentInfo(aliceKeyPair.address)).weight;
     const overallWeight = moonbaseHelper.calculateXcmTransactOverallWeight(payloadExtrinsicWeight);
-    const fee = moonbaseHelper.api.call.transactionPaymentApi.queryWeightToFee(overallWeight);
+    const fee = await moonbaseHelper.api.call.transactionPaymentApi.queryWeightToFee(overallWeight);
 
     const taskExtrinsic = createAutomationTaskExtrinsic({
         turingHelper,

--- a/src/moonbeam/moonbase-local.js
+++ b/src/moonbeam/moonbase-local.js
@@ -240,7 +240,7 @@ const main = async () => {
 
     const payloadExtrinsicWeight = (await payloadExtrinsic.paymentInfo(aliceKeyPair.address)).weight;
     const overallWeight = moonbaseHelper.calculateXcmTransactOverallWeight(payloadExtrinsicWeight);
-    const fee = moonbaseHelper.weightToFee(overallWeight, 'UNIT');
+    const fee = moonbaseHelper.api.call.transactionPaymentApi.queryWeightToFee(overallWeight);
 
     const taskExtrinsic = createAutomationTaskExtrinsic({
         turingHelper,


### PR DESCRIPTION
1. Reimplement `moonbaseHelper.getProxyAccount`.
2. Modify `WEIGHT_PROOF_SIZE` in `config/moonbase-local.js` and `config/moonbase-alpha.js`.
3. Use `moonbaseHelper.api.call.transactionPaymentApi.queryWeightToFee(weight)` to obtain the fee of a moonbase encoded call with native token(DEV, UNIT).
4. Listen to TaskScheduled event and retrieved TaskId