### PR TITLE
Update Rocstar test with OAK-blockchain v2.0.0

### DIFF
--- a/src/astar/rocstar.js
+++ b/src/astar/rocstar.js
@@ -123,7 +123,7 @@ const main = async () => {
     console.log(`\na) Add a proxy for ${account.name} If there is none setup on ${parachainName} (paraId:${turingHelper.config.paraId}) \n`);
 
     const proxyTypeParachain = 'Any'; // We cannotset proxyType to "DappsStaking" without the actual auto-restake call
-    const proxyOnParachain = shibuyaHelper.getProxyAccount(turingAddress, turingHelper.config.paraId);
+    const proxyOnParachain = shibuyaHelper.getProxyAccount(parachainAddress, turingHelper.config.paraId);
     const proxies = await shibuyaHelper.getProxies(parachainAddress);
     const proxyMatch = _.find(proxies, { delegate: proxyOnParachain, proxyType: proxyTypeParachain });
 

--- a/src/astar/rocstar.js
+++ b/src/astar/rocstar.js
@@ -41,7 +41,7 @@ const scheduleTask = async ({
     const assetLocation = shibuyaHelper.getNativeAssetLocation();
     const taskViaProxy = turingHelper.api.tx.automationTime.scheduleXcmpTaskThroughProxy(
         { Fixed: { executionTimes: [nextExecutionTime, timestampTwoHoursLater] } },
-        { V3: { parents: 1, interior: { X1: { Parachain: shibuyaHelper.config.paraId } } } },
+        shibuyaHelper.getLocation(),
         { V3: assetLocation },
         { assetLocation: { V3: assetLocation }, amount: payloadViaProxyFees },
         encodedCallData,

--- a/src/astar/rocstar.js
+++ b/src/astar/rocstar.js
@@ -11,7 +11,7 @@ import {
 import { TuringStaging, Rocstar } from '../config';
 import Account from '../common/account';
 
-const MIN_BALANCE_IN_PROXY = 5; // The proxy accounts are to be topped up if its balance fails below this number
+const MIN_BALANCE_IN_PROXY = 10; // The proxy accounts are to be topped up if its balance fails below this number
 const TASK_FREQUENCY = 3600;
 
 const keyring = new Keyring({ type: 'sr25519' });
@@ -139,8 +139,7 @@ const main = async () => {
 
     if (proxyBalance.free.lt(minBalance)) {
         console.log(`\nTopping up the proxy account on Shibuya with ${symbol} ...\n`);
-        const amountBN = minBalance.muln(2);
-        const topUpExtrinsic = shibuyaHelper.api.tx.balances.transfer(proxyOnParachain, amountBN.toString());
+        const topUpExtrinsic = shibuyaHelper.api.tx.balances.transfer(proxyOnParachain, minBalance.toString());
         await sendExtrinsic(shibuyaHelper.api, topUpExtrinsic, keyPair);
 
         // Retrieve the latest balance after top-up

--- a/src/astar/rocstar.js
+++ b/src/astar/rocstar.js
@@ -38,11 +38,12 @@ const scheduleTask = async ({
     // The parameter "Fixed: { executionTimes: [0] }" will trigger the task immediately, while in real world usage Recurring can achieve every day or every week
     const nextExecutionTime = getHourlyTimestamp(1) / 1000;
     const timestampTwoHoursLater = getHourlyTimestamp(2) / 1000;
+    const assetLocation = shibuyaHelper.getNativeAssetLocation();
     const taskViaProxy = turingHelper.api.tx.automationTime.scheduleXcmpTaskThroughProxy(
         { Fixed: { executionTimes: [nextExecutionTime, timestampTwoHoursLater] } },
         { V3: { parents: 1, interior: { X1: { Parachain: shibuyaHelper.config.paraId } } } },
-        { V3: { parents: 1, interior: { X1: { Parachain: shibuyaHelper.config.paraId } } } },
-        { asset_location: { V3: { parents: 1, interior: { X1: { Parachain: shibuyaHelper.config.paraId } } } }, amount: payloadViaProxyFees },
+        { V3: assetLocation },
+        { assetLocation: { V3: assetLocation }, amount: payloadViaProxyFees },
         encodedCallData,
         encodedCallWeight,
         payloadOverallWeight,

--- a/src/astar/shibuya.js
+++ b/src/astar/shibuya.js
@@ -32,7 +32,7 @@ const scheduleTask = async ({
     const payloadViaProxyFees = await payloadViaProxy.paymentInfo(parachainAddress);
     const encodedCallWeight = payloadViaProxyFees.weight;
     const overallWeight = shibuyaHelper.calculateXcmTransactOverallWeight(encodedCallWeight);
-    const fee = shibuyaHelper.weightToFee(overallWeight, 'SBY');
+    const fee = await shibuyaHelper.api.call.transactionPaymentApi.queryWeightToFee(overallWeight);
 
     console.log(`Encoded call data: ${encodedCallData}`);
     console.log(`Encoded call weight: ${encodedCallWeight}`);

--- a/src/astar/shibuya.js
+++ b/src/astar/shibuya.js
@@ -48,11 +48,12 @@ const scheduleTask = async ({
 
     // TODO: add select prompt to let user decide whether to trigger immediately or at next hour
     // Currently the task trigger immediately in dev environment
+    const assetLocation = shibuyaHelper.getNativeAssetLocation();
     const taskViaProxy = turingHelper.api.tx.automationTime.scheduleXcmpTaskThroughProxy(
         { Fixed: { executionTimes: [0] } },
         { V3: { parents: 1, interior: { X1: { Parachain: shibuyaHelper.config.paraId } } } },
-        { V3: { parents: 1, interior: { X1: { Parachain: shibuyaHelper.config.paraId } } } },
-        { asset_location: { V3: { parents: 1, interior: { X1: { Parachain: shibuyaHelper.config.paraId } } } }, amount: fee },
+        { V3: assetLocation },
+        { assetLocation: { V3: assetLocation }, amount: fee },
         encodedCallData,
         encodedCallWeight,
         overallWeight,

--- a/src/astar/shibuya.js
+++ b/src/astar/shibuya.js
@@ -51,7 +51,7 @@ const scheduleTask = async ({
     const assetLocation = shibuyaHelper.getNativeAssetLocation();
     const taskViaProxy = turingHelper.api.tx.automationTime.scheduleXcmpTaskThroughProxy(
         { Fixed: { executionTimes: [0] } },
-        { V3: { parents: 1, interior: { X1: { Parachain: shibuyaHelper.config.paraId } } } },
+        shibuyaHelper.getLocation(),
         { V3: assetLocation },
         { assetLocation: { V3: assetLocation }, amount: fee },
         encodedCallData,

--- a/src/common/shibuyaHelper.js
+++ b/src/common/shibuyaHelper.js
@@ -6,7 +6,9 @@ import { hexToU8a, u8aToHex } from '@polkadot/util';
 import { TypeRegistry } from '@polkadot/types';
 import Keyring from '@polkadot/keyring';
 
-import { WEIGHT_REF_TIME_PER_SECOND, calculateXcmOverallWeight, getProxies } from './utils';
+import {
+    WEIGHT_REF_TIME_PER_SECOND, calculateXcmOverallWeight, getProxies, paraIdToLocation,
+} from './utils';
 
 class ShibuyaHelper {
     constructor(config) {
@@ -165,6 +167,8 @@ class ShibuyaHelper {
         const { location } = _.find(this.assets, { symbol });
         return location;
     };
+
+    getLocation = () => paraIdToLocation(this.config.paraId);
 
     getNativeAssetLocation = () => this.getAssetLocation(this.config.symbol);
 }

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -275,3 +275,4 @@ export const calculateXcmOverallWeight = (transactCallWeight, instructionWeight,
 
 export const findEvent = (events, section, method) => events.find((e) => e.event.section === section && e.event.method === method);
 export const getTaskIdInTaskScheduledEvent = (event) => Buffer.from(event.event.data.taskId).toString();
+export const paraIdToLocation = (paraId) => ({ parents: 1, interior: { X1: { Parachain: paraId } } });

--- a/src/config/rocstar.js
+++ b/src/config/rocstar.js
@@ -1,3 +1,8 @@
+import BN from 'bn.js';
+
+const WEIGHT_REF_TIME = new BN(1_000_000_000);
+const WEIGHT_PROOF_SIZE = new BN(64 * 1024);
+
 const assets = [
     {
         symbol: 'RSTR',
@@ -13,6 +18,7 @@ const Config = {
     paraId: 2006,
     ss58: 5,
     assets,
+    instructionWeight: { refTime: WEIGHT_REF_TIME, proofSize: WEIGHT_PROOF_SIZE },
 };
 
 export default Config;

--- a/src/config/shibuya.js
+++ b/src/config/shibuya.js
@@ -1,13 +1,12 @@
 import BN from 'bn.js';
 
 const WEIGHT_REF_TIME = new BN(1_000_000_000);
-const WEIGHT_PROOF_SIZE = new BN(1024);
+const WEIGHT_PROOF_SIZE = new BN(64 * 1024);
 
 const assets = [
     {
         symbol: 'SBY',
         decimals: 18,
-        feePerSecond: new BN('10000000000000000000'),
     },
 ];
 

--- a/src/config/turing-staging.js
+++ b/src/config/turing-staging.js
@@ -1,7 +1,17 @@
+import BN from 'bn.js';
+
+const WEIGHT_REF_TIME = new BN(1_000_000_000);
+const WEIGHT_PROOF_SIZE = new BN(0);
+
 const assets = [
     {
         symbol: 'TUR',
         decimals: 10,
+    },
+    {
+        symbol: 'RSTR',
+        decimals: 18,
+        feePerSecond: new BN('2000000'),
     },
 ];
 
@@ -13,6 +23,7 @@ const Config = {
     paraId: 2114,
     ss58: 51,
     assets,
+    instructionWeight: { refTime: WEIGHT_REF_TIME, proofSize: WEIGHT_PROOF_SIZE },
 };
 
 export default Config;


### PR DESCRIPTION
1. Reimplement `shibuyaHelper.getProxyAccount`.
2. Modify `WEIGHT_PROOF_SIZE` in `config/shibuya.js` and `config/rocstar.js`.
3. Use `shibuyaHelper.api.call.transactionPaymentApi.queryWeightToFee(weight)` to obtain the fee of a rocstar encoded call with native token(SBY, RSTR).